### PR TITLE
prevent warning

### DIFF
--- a/libraries/Maniaplanet/DedicatedServer/Xmlrpc/Request.php
+++ b/libraries/Maniaplanet/DedicatedServer/Xmlrpc/Request.php
@@ -40,7 +40,7 @@ if(extension_loaded('xmlrpc'))
 
 			if($method === null)
 			{
-				if(@xmlrpc_is_fault($value))
+				if(is_array($value) && @xmlrpc_is_fault($value))
 					return array('fault', $value);
 				return array('response', $value);
 			}


### PR DESCRIPTION
'xmlrpc_is_fault expects first parameter to be array'
